### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ macosinstall.md
 a.java
 python3.8/
 python3-8/
+
+# Include .vscode resource that is a legitimate part of the build
+!scalpel/src/main/resources/venv/.vscode

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scalpel/build.gradle
+++ b/scalpel/build.gradle
@@ -13,7 +13,7 @@ java {
 }
 
 group 'lexfo'
-version '1.0.0'
+version '1.0.1'
 
 repositories {
     mavenLocal()

--- a/scalpel/build.gradle
+++ b/scalpel/build.gradle
@@ -18,7 +18,9 @@ version '1.0.0'
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
+    maven {
+        url "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies"
+    }
 }
 
 
@@ -36,7 +38,7 @@ dependencies {
     implementation 'org.jetbrains.jediterm:jediterm-pty:2.42'
     implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'log4j:log4j:1.2.17'
-    implementation 'org.jetbrains.pty4j:pty4j:0.12.11'
+    implementation 'org.jetbrains.pty4j:pty4j:0.13.12'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0-rc2'
 

--- a/scalpel/src/main/resources/venv/.vscode/settings.json
+++ b/scalpel/src/main/resources/venv/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"terminal.integrated.env.linux": {
+		"PYTHONPATH": "${env:HOME}/.scalpel/extracted/python3-10:${env:HOME}/.scalpel/extracted/python3-8::${env:PYTHONPATH}",
+		"PATH": "${env:HOME}/.scalpel/extracted/python3-10:${env:HOME}/.scalpel/extracted/python3-8:${env:PATH}"
+	},
+
+	"python.analysis.extraPaths": [
+		"../../extracted/python3-10",
+		"../../extracted/python3-8"
+	]
+}


### PR DESCRIPTION
Main motivation is to fix scalpel on burp v2026.6, which moved to Java 26.

* Use newer gradle that supports building on Java 26
* Replaced deprecated jcenter repo with direct JetBrains repo
* Update pty4j to a version depending on JNA compatible with Java 26